### PR TITLE
frame_id missing in leg tracker

### DIFF
--- a/leg_detector/src/leg_detector.cpp
+++ b/leg_detector/src/leg_detector.cpp
@@ -979,6 +979,7 @@ public:
 
     people_msgs::PositionMeasurementArray array;
     array.header.stamp = ros::Time::now();
+    array.header.frame_id = fixed_frame;
     if (publish_legs_)
     {
       array.people = legs;


### PR DESCRIPTION
PositionMeasurementArray was published without frame_id